### PR TITLE
Visual feedback on mobile&desktop

### DIFF
--- a/src/lib/components/Keyboard.css
+++ b/src/lib/components/Keyboard.css
@@ -73,7 +73,7 @@ html {
 }
 
 .simple-keyboard.hg-theme-default .hg-button.hg-activeButton {
-  background: #a6a6a6;
+  background: #efefef;
 }
 
 /* When using option "useButtonTag" */

--- a/src/lib/components/Keyboard.css
+++ b/src/lib/components/Keyboard.css
@@ -69,6 +69,11 @@ html {
   display: flex;
   align-items: center;
   justify-content: center;
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+}
+
+.simple-keyboard.hg-theme-default .hg-button.hg-activeButton {
+  background: #a6a6a6;
 }
 
 /* When using option "useButtonTag" */

--- a/src/lib/components/Keyboard.js
+++ b/src/lib/components/Keyboard.js
@@ -84,6 +84,8 @@ class SimpleKeyboard {
     this.options.inputName = this.options.inputName || "default";
     this.options.preventMouseDownDefault =
       this.options.preventMouseDownDefault || false;
+    if (this.options.autUseTouchEvents === undefined)
+      this.options.autoUseTouchEvents = true;
 
     /**
      * @type {object} Classes identifying loaded plugins
@@ -1176,6 +1178,8 @@ class SimpleKeyboard {
           buttonDOM.setAttribute(attribute, value);
         });
 
+        const hgActiveButtonClass = "hg-activeButton";
+
         /**
          * Handle button click event
          */
@@ -1189,11 +1193,18 @@ class SimpleKeyboard {
            * Handle PointerEvents
            */
           buttonDOM.onpointerdown = e => {
+            buttonDOM.classList.add(hgActiveButtonClass);
             this.handleButtonClicked(button);
             this.handleButtonMouseDown(button, e);
           };
-          buttonDOM.onpointerup = () => this.handleButtonMouseUp(button);
-          buttonDOM.onpointercancel = () => this.handleButtonMouseUp(button);
+          buttonDOM.onpointerup = () => {
+            buttonDOM.classList.remove(hgActiveButtonClass);
+            this.handleButtonMouseUp(button);
+          };
+          buttonDOM.onpointercancel = () => {
+            buttonDOM.classList.remove(hgActiveButtonClass);
+            this.handleButtonMouseUp(button);
+          };
         } else {
           /**
            * Fallback for browsers not supporting PointerEvents
@@ -1203,11 +1214,18 @@ class SimpleKeyboard {
              * Handle touch events
              */
             buttonDOM.ontouchstart = e => {
+              buttonDOM.classList.add(hgActiveButtonClass);
               this.handleButtonClicked(button);
               this.handleButtonMouseDown(button, e);
             };
-            buttonDOM.ontouchend = () => this.handleButtonMouseUp(button);
-            buttonDOM.ontouchcancel = () => this.handleButtonMouseUp(button);
+            buttonDOM.ontouchend = () => {
+              buttonDOM.classList.remove(hgActiveButtonClass);
+              this.handleButtonMouseUp(button);
+            };
+            buttonDOM.ontouchcancel = () => {
+              buttonDOM.classList.remove(hgActiveButtonClass);
+              this.handleButtonMouseUp(button);
+            };
           } else {
             /**
              * Handle mouse events
@@ -1216,8 +1234,14 @@ class SimpleKeyboard {
               this.isMouseHold = false;
               this.handleButtonClicked(button);
             };
-            buttonDOM.onmousedown = e => this.handleButtonMouseDown(button, e);
-            buttonDOM.onmouseup = () => this.handleButtonMouseUp(button);
+            buttonDOM.onmousedown = e => {
+              buttonDOM.classList.add(hgActiveButtonClass);
+              this.handleButtonMouseDown(button, e);
+            };
+            buttonDOM.onmouseup = () => {
+              buttonDOM.classList.remove(hgActiveButtonClass);
+              this.handleButtonMouseUp(button);
+            };
           }
         }
 

--- a/src/lib/components/Keyboard.js
+++ b/src/lib/components/Keyboard.js
@@ -84,8 +84,6 @@ class SimpleKeyboard {
     this.options.inputName = this.options.inputName || "default";
     this.options.preventMouseDownDefault =
       this.options.preventMouseDownDefault || false;
-    if (this.options.autUseTouchEvents === undefined)
-      this.options.autoUseTouchEvents = true;
 
     /**
      * @type {object} Classes identifying loaded plugins


### PR DESCRIPTION
## Description

First of all: Thank you for this great library. It's really useful und customizable.

There is only one thing missing: proper visual feedback. Hassling around with `:active` was not satisfying for mobile, so my suggestion would be to handle the active state of a button with javascript.

This PR toggles a `hg-activeButton` class on the currently pressed button. You can now style the button with css. The styling is consistent between desktop and Chrome / FF. I wasn't able to test it on iOS yet. Add `autoUseTouchEvents` to the BasicDemo to test it on mobile.

I would be glad if you could review this PR.

Tests are running fine, the documentation script was not found?

## Checks

- [x] Tests ( `npm run test -- --coverage` ) Coverage at `./coverage/lcov-report/index.html` should be 100%