### PR TITLE
npmignore: add webpack.config.{demo,modern}.js

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -33,4 +33,6 @@ README.md
 .eslintignore
 .eslintrc.json
 webpack.config.js
+webpack.config.demo.js
+webpack.config.modern.js
 babel.config.js


### PR DESCRIPTION
## Description

The build config files webpack.config.{demo,modern}.js do not need to be published.