### PR TITLE
fix: onInit and onRender are always called with the instance

### DIFF
--- a/src/lib/interfaces.ts
+++ b/src/lib/interfaces.ts
@@ -264,12 +264,12 @@ export interface KeyboardOptions {
     /**
      * Executes the callback function every time simple-keyboard is rendered (e.g: when you change layouts).
      */
-     onRender?: (instance?: SimpleKeyboard) => void;
+     onRender?: (instance: SimpleKeyboard) => void;
 
     /**
      * Executes the callback function once simple-keyboard is rendered for the first time (on initialization).
      */
-     onInit?: (instance?: SimpleKeyboard) => void;
+     onInit?: (instance: SimpleKeyboard) => void;
 
     /**
      * Retrieves the current input


### PR DESCRIPTION
## Description

The type declaration for the KeyboardOptions seems inaccurate, `onInit` and `onRender` are always called with an instance of SimpleKeyboard.

## Checks

- [x] Tests ( `npm run test -- --coverage` ) Coverage at `./coverage/lcov-report/index.html` should be 100%
