### PR TITLE
Distribute the currently active input element to each virtual keyboard instance.

### DIFF
--- a/src/lib/components/Keyboard.ts
+++ b/src/lib/components/Keyboard.ts
@@ -1260,7 +1260,7 @@ class SimpleKeyboard {
         /**
          * Tracking current input in order to handle caret positioning edge cases
          */
-        this.activeInputElement = event.target;
+        instance.activeInputElement = event.target;
 
         if (instance.options.debug) {
           console.log(
@@ -1284,7 +1284,7 @@ class SimpleKeyboard {
         /**
          * Resetting activeInputElement
          */
-        this.activeInputElement = null;
+        instance.activeInputElement = null;
 
         if (instance.options.debug) {
           console.log(


### PR DESCRIPTION
## Description

Distribute the currently active input element to each virtual keyboard instance for access in **onKeyPress()** or other locations. this change makes it easier for you to know which input element is used to calculate **this.caretposition** and **this.caretpositionEnd** for the current virtual keyboard instance. 
Resolves  #2301 .

## Checks

- [x] I have read and followed the [Contributing Guidelines](https://github.com/hodgef/simple-keyboard/blob/master/CONTRIBUTING.md).
