### PR TITLE
fix: prevent svg from being the event target of oncontextmenu

### DIFF
--- a/src/lib/components/css/Keyboard.css
+++ b/src/lib/components/css/Keyboard.css
@@ -15,7 +15,9 @@
   border-radius: 5px;
 }
 
-.hg-theme-default .hg-button span {
+.hg-theme-default .hg-button span,
+.hg-theme-default .hg-button span svg
+ {
   pointer-events: none;
 }
 


### PR DESCRIPTION
## Description

When an SVG is the event target of an `oncontextmenu` handler, an exception is thrown when evaluating `event.target.classList.contains("hg-button")`. This PR adds a CSS selector that specifically targets svgs with the rule `pointer-events: none;`

## Checks

- [x] I have read and followed the [Contributing Guidelines](https://github.com/hodgef/simple-keyboard/blob/master/CONTRIBUTING.md).
