### PR TITLE
Add undefined check to oncontextmenu handler

### DIFF
--- a/src/lib/components/Keyboard.ts
+++ b/src/lib/components/Keyboard.ts
@@ -1495,7 +1495,7 @@ class SimpleKeyboard {
   /* istanbul ignore next */
   disableContextualWindow() {
     window.oncontextmenu = (event: KeyboardHandlerEvent) => {
-      if (event.target.classList.contains("hg-button")) {
+      if (event.target.classList?.contains("hg-button")) {
         event.preventDefault();
         event.stopPropagation();
         return false;


### PR DESCRIPTION
## Description

This PR adds a `?` to the oncontextmenu handler

```typescript
  window.oncontextmenu = (event: KeyboardHandlerEvent) => {
      if (event.target.classList?.contains("hg-button")) {
          ...
```

Occasionally I've noticed this event handler trigger for targets that do not have `classList` (perhaps `window` or `Document`?) and an error is thrown from this handler when `.contains` is accessed on `undefined`. 

## Checks

- [x] I have read and followed the [Contributing Guidelines](https://github.com/hodgef/simple-keyboard/blob/master/CONTRIBUTING.md).
